### PR TITLE
[Salt-cloud] Allow to ignore ssl with Xen provider

### DIFF
--- a/salt/cloud/clouds/xen.py
+++ b/salt/cloud/clouds/xen.py
@@ -150,7 +150,14 @@ def _get_session():
         __opts__,
         search_global=False
     )
-    session = XenAPI.Session(url)
+    ignore_ssl = config.get_cloud_config_value(
+        'ignore_ssl',
+        get_configured_provider(),
+        __opts__,
+        default=False,
+        search_global=False
+    )
+    session = XenAPI.Session(url,ignore_ssl=ignore_ssl)
     log.debug('url: {} user: {} password: {}, originator: {}'.format(
         url,
         user,


### PR DESCRIPTION
### What does this PR do?

Allow to ignore ssl verification for xen providers

# /etc/salt/cloud.providers.d/xentest.conf
xentest:
  ignore_ssl: True
  driver: xen

Require a recent XenAPI.py which can be found here: https://github.com/xapi-project/xen-api/blob/master/scripts/examples/python/XenAPI.py

### What issues does this PR fix or reference?

### Previous Behavior
SSL verification cannot be ignored for xenserver providers
### New Behavior
Allow to ignore SSL verification within  cloud.providers config file

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
